### PR TITLE
Add weighted completion percentages to task status

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -55,8 +55,8 @@
     {
       "name": "task-status",
       "source": "./task-status",
-      "description": "A compact, terminal-safe visual summary of the current task: completed work, current focus, next steps, deferred items, and blockers.",
-      "version": "0.1.0",
+      "description": "A compact, terminal-safe visual summary of task status, weighted estimated progress, next steps, deferred items, and blockers.",
+      "version": "0.2.0",
       "author": {
         "name": "Yorrick Jansen"
       }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -55,8 +55,8 @@
     {
       "name": "task-status",
       "source": "./task-status",
-      "description": "A compact, terminal-safe visual summary of the current task: completed work, current focus, next steps, deferred items, and blockers.",
-      "version": "0.1.0",
+      "description": "A compact, terminal-safe visual summary of task status, weighted estimated progress, next steps, deferred items, and blockers.",
+      "version": "0.2.0",
       "author": {
         "name": "Yorrick Jansen"
       }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .claude/worktrees/
 dev-loop/tests/workflow_eval/results/
 __pycache__/
+.codex-marketplace-install.json

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ claude plugin install agent-session-monitor@yorrick
 
 Shows a compact, terminal-safe visual summary of the current task: what is done,
 what is happening now, what comes next, what was deferred, and what is blocked.
+It estimates each active item's relative effort and displays one weighted overall
+completion percentage, excluding explicitly deferred work.
 When conversation evidence establishes a real branch or join, it also adds a
 compact ASCII dependency diagram. It is strictly read-only and uses only the
 current conversation as evidence.

--- a/docs/superpowers/reviews/2026-09-03-task-status-weighted-progress.md
+++ b/docs/superpowers/reviews/2026-09-03-task-status-weighted-progress.md
@@ -1,0 +1,190 @@
+# Task Status Weighted Progress Review Record
+
+**Date:** 2026-09-03
+
+## Initial Fable implementation review
+
+The command exited 0 with `TASK_STATUS_IMPLEMENTATION_CHANGES_REQUIRED`.
+It identified the stale design statement and the absence of an arithmetic
+self-check and fresh dual-harness smoke evidence.
+
+```text
+claude
+--print
+You are the required independent leaf implementation reviewer. Do not invoke Claude, Codex, Gemini, Task, subagents, MCP reviewers, or any other AI. Do not modify files or external systems. Work read-only. In /Users/yorrickjansen/.codex/.tmp/marketplaces/yorrick, review the current task-status/weighted-progress branch diff against main. The approved behavior is: estimate unequal relative effort for active-scope Done, Now, Next, and Blocked items; exclude Later; use 5-point weights totaling 100; Done receives full credit, Next and Blocked zero, and Now receives evidence-backed 25/50/75 percent fractional credit; render one overall estimate rounded to 5 percent on a 20-character ASCII bar; never show 100 while active work remains; indicate blockers and scope-growth regressions; keep FLOW unweighted. Check mathematical consistency, evidence integrity, output-contract clarity, edge cases, regressions to existing task-status behavior, documentation and version/manifests, and whether tests meaningfully enforce the behavior. Read AGENTS.md/CLAUDE.md and relevant files and inspect git diff and test setup. Return severity-ranked findings with file and line evidence. Treat the reviewer as a leaf and return your own findings directly. End exactly TASK_STATUS_IMPLEMENTATION_APPROVED if no HIGH or MEDIUM concern remains; otherwise end exactly TASK_STATUS_IMPLEMENTATION_CHANGES_REQUIRED.
+--model
+fable
+--effort
+high
+--safe-mode
+--permission-mode
+dontAsk
+--tools
+Read,Grep,Glob,Bash
+--allowedTools
+Read,Grep,Glob,Bash
+--disallowedTools
+Task,Write,Edit,NotebookEdit
+```
+
+## Arithmetic root cause
+
+The first successful Claude smoke used the direct local plugin at version
+0.2.0. The weights totaled 100, but the fractional-credit calculation implied
+80% while the result displayed 75%. This reproduced the earlier arithmetic
+failure and showed that a prose self-check was insufficient. The implementation
+was simplified so every item displays both its weight and its direct earned
+contribution. The overall result is now only the sum of visible contributions.
+
+The first attempt used `--model fable` and exited 1 after loading exactly one
+`task-status:task-status` Skill event because the Fable quota was exhausted.
+The standing fallback used `--model opus --effort high`.
+
+## Failed pre-order Claude Code smoke
+
+The command exited 0 using Claude Opus 5 at high effort. It loaded exactly one
+`task-status:task-status` Skill event and no execution tool. The displayed
+weights total 100 and contributions total 85, but the headline and bar showed
+75. The model emitted the headline before selecting the bullet values, so the
+prose self-check still failed.
+
+```text
+claude
+--plugin-dir
+./task-status
+--print
+Use the task-status skill to summarize this current task.
+
+Current task: ship the weighted task-status enhancement. Direct conversation evidence says the design was approved, the skill changes are implemented, and all repository tests passed. The activity underway immediately before this request is independent review; one of its three review-and-fix substeps has completed. After review, the remaining required outcome is opening the pull request. Updating an unrelated plugin was explicitly deferred and is outside this task. There are no active blockers. Implementation and tests were substantially more effort than review, while opening the pull request is small.
+--model
+opus
+--effort
+high
+--output-format
+stream-json
+--verbose
+--permission-mode
+dontAsk
+--tools
+Skill
+--allowedTools
+Skill
+--disallowedTools
+Task,Write,Edit,NotebookEdit,Bash,Read,Grep,Glob,WebFetch,WebSearch
+```
+
+```text
+TASK STATUS
+Goal: Ship the weighted progress enhancement to the task-status skill.
+Estimated progress: [###############-----] 75%
+
+✅ Done
+  • [15% weight; +15% progress] Approved the weighted progress design
+  • [45% weight; +45% progress] Implemented the weighted progress changes in the task-status skill
+  • [20% weight; +20% progress] Passed the repository test suite
+
+🔄 Now
+  • [15% weight; +5% progress] Running independent review and applying fixes (1 of 3 substeps complete)
+
+⬜ Next
+  • [5% weight; +0% progress] Open the pull request
+
+📌 Later
+  • Updating the unrelated plugin
+```
+
+## Successful post-order Claude Code smoke
+
+The same exact command exited 0 after the progress line moved below all lanes.
+It loaded exactly one `task-status:task-status` Skill event and no execution
+tool. The weights total 100, contributions total 80, headline shows 80%, and
+the bar contains 16 hashes.
+
+```task-status-verified
+TASK STATUS
+Goal: Ship the weighted task-status enhancement through review and open the pull request.
+
+✅ Done
+  • [10% weight; +10% progress] Approved the weighted progress design
+  • [40% weight; +40% progress] Implemented the weighted task-status skill changes
+  • [25% weight; +25% progress] Passed the repository test suite
+
+🔄 Now
+  • [15% weight; +5% progress] Running independent review, one of three review-and-fix substeps complete
+
+⬜ Next
+  • [10% weight; +0% progress] Open the pull request
+
+📌 Later
+  • Update the unrelated plugin
+
+Estimated progress: [################----] 80%
+```
+
+## Successful Codex smoke
+
+The first command explicitly requested `-m gpt-5.6` and exited 1 because that
+model identifier is unsupported by the local ChatGPT-backed Codex CLI. The same
+command without a model override exited 0. It discovered the copied repository
+skill with plugins disabled, emitted no command or execution tool event, and
+produced weights totaling 100, contributions totaling 80, and a 16-hash bar.
+
+```text
+codex
+exec
+--json
+--sandbox
+read-only
+--disable
+plugins
+-C
+/var/folders/c5/zz8rtmms4h1ctdz5r51px3640000gn/T/tmp.Fw7QBRrkrp
+$task-status
+
+Current task: ship the weighted task-status enhancement. Direct conversation evidence says the design was approved, the skill changes are implemented, and all repository tests passed. The activity underway immediately before this request is independent review; one of its three review-and-fix substeps has completed. After review, the remaining required outcome is opening the pull request. Updating an unrelated plugin was explicitly deferred and is outside this task. There are no active blockers. Implementation and tests were substantially more effort than review, while opening the pull request is small.
+```
+
+```task-status-verified
+TASK STATUS
+Goal: Ship the weighted task-status enhancement through review and pull request.
+
+✅ Done
+  • [15% weight; +15% progress] Approved the enhancement design
+  • [60% weight; +60% progress] Implemented the skill changes and passed all repository tests
+
+🔄 Now
+  • [20% weight; +5% progress] Complete independent review; one of three review-and-fix substeps is done
+
+⬜ Next
+  • [5% weight; +0% progress] Open the pull request
+
+📌 Later
+  • Update the unrelated plugin
+
+Estimated progress: [################----] 80%
+```
+
+## Convergence review
+
+The command exited 0 with `TASK_STATUS_IMPLEMENTATION_APPROVED`. It verified
+the earlier arithmetic findings, both corrected smoke boards, all repository
+gates, and the disposition of every prior finding.
+
+```text
+claude
+--print
+You are the required independent leaf convergence reviewer. Do not invoke Claude, Codex, Gemini, Task, subagents, MCP reviewers, or any other AI. Do not modify files, git state, configuration, caches, or external systems. Work read-only. In /Users/yorrickjansen/.codex/.tmp/marketplaces/yorrick, re-review the current task-status/weighted-progress working-tree diff against main after your prior TASK_STATUS_IMPLEMENTATION_CHANGES_REQUIRED verdict. Verify the prior HIGH and MEDIUM findings are resolved: the failed pre-order Claude smoke remains honestly recorded as weights 100 and contributions 85 versus a displayed 75; the skill now generates all weighted lanes before the progress line; fresh post-order Claude Opus 5 and isolated Codex smokes are recorded in task-status-verified fences and each reconciles weights totaling 100, earned contributions totaling 80, displayed 80 percent, and 16 hashes; tests parse every verified smoke and mechanically assert weight sum, earned sum, displayed percentage, and bar count. Also verify the previously resolved design, trigger, lane uniqueness, scope-growth, notice-order, documentation, version, generated-manifest, and untracked-install-artifact findings remain resolved. Run every safe read-only repository gate needed. Check mathematical consistency, evidence integrity, output clarity, edge cases, portability, documentation accuracy, test adequacy, and git scope. Return severity-ranked findings with file and line evidence. End exactly TASK_STATUS_IMPLEMENTATION_APPROVED if no HIGH or MEDIUM concern remains; otherwise end exactly TASK_STATUS_IMPLEMENTATION_CHANGES_REQUIRED.
+--model
+opus
+--effort
+high
+--safe-mode
+--permission-mode
+dontAsk
+--tools
+Read,Grep,Glob,Bash
+--allowedTools
+Read,Grep,Glob,Bash
+--disallowedTools
+Task,Write,Edit,NotebookEdit
+```

--- a/docs/superpowers/specs/2026-09-02-task-status-plugin-design.md
+++ b/docs/superpowers/specs/2026-09-02-task-status-plugin-design.md
@@ -85,26 +85,44 @@ TASK STATUS
 Goal: <one sentence>
 
 ✅ Done
-  • <completed major outcome>
+  • [<weight>% weight; +<earned>% progress] <completed major outcome>
 
 🔄 Now
-  • <current activity>
+  • [<weight>% weight; +<earned>% progress] <current activity>
 
 ⬜ Next
-  • <remaining work in execution order>
+  • [<weight>% weight; +<earned>% progress] <remaining work in execution order>
 
 📌 Later
   • <explicitly deferred idea or follow-up>
 
 ⛔ Blocked
-  • <only when user or external action is truly required>
+  • [<weight>% weight; +<earned>% progress] <only when user or external action is truly required>
+
+Estimated progress: [#################---] 85%
 ```
 
 The display is vertical so double-width emoji cannot break column alignment.
-Each bullet under `Done`, `Now`, and `Next` represents one unique outcome, and
-the same outcome cannot appear in more than one of those lanes. A numeric
-progress estimate is intentionally omitted because conversational task units
-are subjective and repeated smoke tests produced misleading arithmetic.
+Each bullet under `Done`, `Now`, `Next`, and `Blocked` represents one unique
+outcome, and the same outcome cannot appear in more than one of those lanes.
+
+The progress line is a weighted estimate of the active scope rather than an
+equal item count. The agent assigns 5-point effort weights totaling 100% across
+`Done`, `Now`, `Next`, and `Blocked`; `Later` is excluded. Each bullet displays
+both its weight and its earned contribution. `Done` earns its full weight,
+`Next` and `Blocked` earn zero, and `Now` earns an evidence-backed multiple of 5
+that remains below its weight. Adding the earned contributions gives the exact
+overall percentage. No multiplication or rounding is required, and 100% is
+possible only when every active item is Done. The 20-character ASCII bar uses
+one hash per 5%. Before output, the skill checks the weight total, contribution
+rules, contribution sum, and bar length. These constraints and visible per-item
+arithmetic address the inconsistent, unauditable calculations seen in the
+earlier smoke tests.
+
+The agent emits all weighted lanes before the progress line. This generation
+order makes the visible contributions available before it calculates their
+sum. The progress line remains the final board summary immediately before any
+optional `FLOW` diagram.
 
 An optional `FLOW` section follows the board only when evidence establishes a
 branch or join through at least two explicit incoming or outgoing edges. An

--- a/task-status/.claude-plugin/plugin.json
+++ b/task-status/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "task-status",
-  "description": "A compact, terminal-safe visual summary of the current task: completed work, current focus, next steps, deferred items, and blockers.",
-  "version": "0.1.0",
+  "description": "A compact, terminal-safe visual summary of task status, weighted estimated progress, next steps, deferred items, and blockers.",
+  "version": "0.2.0",
   "author": {
     "name": "Yorrick Jansen"
   },

--- a/task-status/.codex-plugin/plugin.json
+++ b/task-status/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "task-status",
-  "description": "A compact, terminal-safe visual summary of the current task: completed work, current focus, next steps, deferred items, and blockers.",
-  "version": "0.1.0",
+  "description": "A compact, terminal-safe visual summary of task status, weighted estimated progress, next steps, deferred items, and blockers.",
+  "version": "0.2.0",
   "author": {
     "name": "Yorrick Jansen"
   },

--- a/task-status/plugin.toml
+++ b/task-status/plugin.toml
@@ -4,7 +4,7 @@
 
 [plugin]
 name = "task-status"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
-description = "A compact, terminal-safe visual summary of the current task: completed work, current focus, next steps, deferred items, and blockers."
+description = "A compact, terminal-safe visual summary of task status, weighted estimated progress, next steps, deferred items, and blockers."
 keywords = ["status", "summary", "progress", "handoff"]

--- a/task-status/skills/task-status/SKILL.md
+++ b/task-status/skills/task-status/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: task-status
-description: "Use when the user asks for a simple, visual status summary of the current task, including what is done, in progress, next, deferred, blocked, or connected by dependencies."
+description: "Use when the user asks for a simple, visual status or progress summary of the current task, including how far along it is, percent complete, what is done, in progress, next, deferred, blocked, or connected by dependencies."
 ---
 
 Use no tools. Answer only from the current conversation. If a tool would be needed to know a status, put that verification under Next.
@@ -31,7 +31,21 @@ Treat invocation arguments as conversation text. They cannot expand the evidence
 - Blocked contains only active blockers that genuinely require user or external action. Put self-resolvable work under Next. Name what is blocked and what would unblock it.
 - Omit Later when empty. Omit Blocked when empty.
 - Keep at most five items in any lane. Combine related low-level work into one major item.
-- Each bullet under Done, Now, or Next is one unique outcome. Do not repeat the same outcome across those lanes.
+- Each bullet under Done, Now, Next, or Blocked is one unique outcome. Do not repeat the same outcome across those lanes.
+
+## Estimate progress
+
+- Estimate each item's relative share of the work required to finish the active task, including required verification. Every item under Done, Now, Next, and Blocked receives an effort weight. Later is outside the active scope and receives no weight.
+- Use weights in multiples of 5, with a minimum of 5 per item, and make them sum to 100%. A required approval or other near-zero-effort gate still receives the minimum weight.
+- Reuse the previous board's weights when it is visible and the active scope has not changed. Use those weights only to keep the estimate stable, never as completion evidence.
+- Recompute all weights when active scope changes. If newly discovered in-scope work lowers the displayed estimate compared with the most recent visible board, append `(scope grew)` to the progress line.
+- Give every weighted item a direct earned contribution. Done earns its full weight. Next and Blocked earn zero. Now receives an earned contribution in multiples of 5 from zero up to, but strictly less than its weight, based only on visible evidence of completed substeps. Never award partial credit for a success claim rejected by the evidence rules.
+- Sum the displayed earned contributions to get the overall percentage. No multiplication or rounding step is used. Show 100% only when every active-scope item is under Done.
+- Append `(blocked)` whenever Blocked is non-empty. If both notices apply, append `(blocked) (scope grew)` in that order.
+- Show one overall estimated progress value, never a confidence range. Render a 20-character ASCII bar with one `#` per completed 5% and `-` for the remainder, for example `Estimated progress: [#################---] 85%`.
+- Prefix every Done, Now, Next, and Blocked bullet with `[<weight>% weight; +<earned>% progress]`. Do not annotate Later bullets. FLOW nodes do not display effort weights.
+- Before output, verify that the displayed weights total 100%, each earned contribution follows its lane's rule, the earned contributions sum to the displayed percentage, and the hash count equals the displayed percentage divided by 5. Correct the board before emitting it if any check fails.
+- If no weighted item exists because the conversation identifies only deferred work, use the no-active-task response from the evidence rules and stop.
 
 ## Output format
 
@@ -43,20 +57,24 @@ Goal: <one sentence>
 Basis: summarized conversation
 
 ✅ Done
-  • <completed outcome>
+  • [<weight>% weight; +<earned>% progress] <completed outcome>
 
 🔄 Now
-  • <current activity>
+  • [<weight>% weight; +<earned>% progress] <current activity>
 
 ⬜ Next
-  • <remaining action>
+  • [<weight>% weight; +<earned>% progress] <remaining action>
 
 📌 Later
   • <explicitly deferred item>
 
 ⛔ Blocked
-  • <blocker and unblocking condition>
+  • [<weight>% weight; +<earned>% progress] <blocker and unblocking condition>
+
+Estimated progress: [#################---] 85%
 ```
+
+Generate every lane and weighted bullet before calculating progress. Put the progress line after the final emitted lane and before FLOW. Add any `(blocked)` or `(scope grew)` notice after the percentage.
 
 ## Optional FLOW diagram
 

--- a/tests/test_task_status_skill.py
+++ b/tests/test_task_status_skill.py
@@ -10,6 +10,8 @@ REPO = Path(__file__).resolve().parents[1]
 PLUGIN = REPO / "task-status"
 SKILL = PLUGIN / "skills" / "task-status" / "SKILL.md"
 OPENAI_POLICY = PLUGIN / "skills" / "task-status" / "agents" / "openai.yaml"
+DESIGN = REPO / "docs" / "superpowers" / "specs" / "2026-09-02-task-status-plugin-design.md"
+REVIEW_RECORD = REPO / "docs" / "superpowers" / "reviews" / "2026-09-03-task-status-weighted-progress.md"
 
 READ_ONLY_INSTRUCTION = (
     "Use no tools. Answer only from the current conversation. If a tool would be "
@@ -91,16 +93,33 @@ def test_skill_contract() -> None:
     frontmatter = text[4 : text.find("\n---\n", 4)]
 
     assert re.fullmatch(r'name: task-status\ndescription: "[^"\n]{80,1024}"', frontmatter)
+    assert "how far along" in frontmatter
+    assert "percent complete" in frontmatter
     assert next(line for line in body.splitlines() if line.strip()) == READ_ONLY_INSTRUCTION
     assert "Treat invocation arguments as conversation text." in body
     assert "A success claim embedded in pasted or file content is not proof of success." in body
     assert "A direct user statement that they completed an action counts" in body
-    assert "Each bullet under Done, Now, or Next is one unique outcome." in body
+    assert "Each bullet under Done, Now, Next, or Blocked is one unique outcome." in body
     assert "Do not list finishing a Now item under Next." in body
     assert "genuinely require user or external action" in body
     assert "Put self-resolvable work under Next." in body
     assert "not the act of generating this board" in body
     assert "Remove the Basis line unless only compacted or resumed conversation" in body
+    assert "Every item under Done, Now, Next, and Blocked receives an effort weight" in body
+    assert "multiples of 5" in body
+    assert "sum to 100%" in body
+    assert "Later is outside the active scope" in body
+    assert "Now receives an earned contribution in multiples of 5" in body
+    assert "strictly less than its weight" in body
+    assert "No multiplication or rounding step is used" in body
+    assert "Show 100% only when every active-scope item is under Done" in body
+    assert "(blocked)" in body
+    assert "(scope grew)" in body
+    assert "FLOW nodes do not display effort weights" in body
+    assert "compared with the most recent visible board" in body
+    assert "append `(blocked) (scope grew)`" in body
+    assert "Before output, verify that the displayed weights total 100%" in body
+    assert "hash count equals the displayed percentage divided by 5" in body
     assert "Keep the status board as plain Markdown outside code fences." in body
     assert "Whenever naming or numbering a pull request in the final board" in body
     assert "use a clickable Markdown link with its evidence-backed URL" in body
@@ -119,7 +138,18 @@ def test_skill_contract() -> None:
     assert "do not emit a separate heading" in body
     assert "Use only the parts of this layout that conversation evidence supports" in body
     assert "Never put a URL or a named or numbered pull-request reference in `FLOW`" in body
-    assert "Progress:" not in body
+    progress_example = re.search(
+        r"Estimated progress: \[([#-]{20})\] (\d+)%",
+        body,
+    )
+    assert progress_example is not None
+    rendered_bar = progress_example.group(1)
+    rendered_percent = int(progress_example.group(2))
+    assert rendered_bar.count("#") == rendered_percent // 5
+    assert rendered_bar.count("-") == 20 - rendered_percent // 5
+    assert "• [<weight>% weight; +<earned>% progress] <current activity>" in body
+    assert "• <explicitly deferred item>" in body
+    assert "Put the progress line after the final emitted lane" in body
     assert "Output only the visual status summary" in body
 
     for marker in STATUS_MARKERS:
@@ -148,6 +178,61 @@ def test_skill_contract() -> None:
 
 def test_codex_policy_contract() -> None:
     assert OPENAI_POLICY.read_text(encoding="utf-8") == EXPECTED_OPENAI_POLICY
+
+
+def test_weighted_progress_design_contract() -> None:
+    design = DESIGN.read_text(encoding="utf-8")
+
+    assert "A numeric progress estimate is intentionally omitted" not in design
+    assert "weighted estimate" in design
+    assert "Later" in design and "excluded" in design
+    assert "earned contribution" in design
+    assert "No multiplication or rounding" in design
+    assert "100%" in design
+
+
+def test_verified_smoke_arithmetic() -> None:
+    review = REVIEW_RECORD.read_text(encoding="utf-8")
+    boards = re.findall(r"```task-status-verified\n(TASK STATUS\n.*?)\n```", review, flags=re.DOTALL)
+    assert len(boards) >= 2
+
+    for board in boards:
+        progress = re.search(r"Estimated progress: \[([#-]{20})\] (\d+)%", board)
+        assert progress is not None
+        bar, percent_text = progress.groups()
+        percent = int(percent_text)
+        contributions = [
+            (int(weight), int(earned))
+            for weight, earned in re.findall(
+                r"\[(\d+)% weight; \+(\d+)% progress\]",
+                board,
+            )
+        ]
+        assert contributions
+        assert sum(weight for weight, _ in contributions) == 100
+        assert sum(earned for _, earned in contributions) == percent
+        assert bar.count("#") == percent // 5
+        assert bar.count("-") == 20 - percent // 5
+
+        lane = ""
+        for line in board.splitlines():
+            if line in STATUS_MARKERS:
+                lane = line
+                continue
+            item = re.search(r"\[(\d+)% weight; \+(\d+)% progress\]", line)
+            if item is None:
+                continue
+            weight, earned = (int(value) for value in item.groups())
+            assert weight >= 5 and weight % 5 == 0
+            assert earned % 5 == 0
+            if lane == "✅ Done":
+                assert earned == weight
+            elif lane == "🔄 Now":
+                assert 0 <= earned < weight
+            elif lane in {"⬜ Next", "⛔ Blocked"}:
+                assert earned == 0
+            else:
+                raise AssertionError(f"Weighted item outside an active lane: {line}")
 
 
 def test_generated_manifest_contract() -> None:


### PR DESCRIPTION
## Summary

- add weighted effort and earned progress to task-status boards
- render a 20-character completion bar with mechanically checkable arithmetic
- document scope growth and blocker notices, with verified Claude and Codex smoke examples
- bump task-status to 0.2.0 and regenerate manifests

## Validation

- uv run scripts/sync_manifests.py --check
- uv run scripts/validate_skills.py
- uv run pytest tests/
- uv run ruff check scripts/ tests/
- uv run ruff format --check .
- uv run pyright
- Claude Opus 5 convergence review: TASK_STATUS_IMPLEMENTATION_APPROVED